### PR TITLE
fix: enable GitHub Pages build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         name: prettier
         entry: npx prettier --write
         language: node
-        types: [javascript, jsx, ts, tsx, json, css, md]
+        types: [javascript, jsx, ts, tsx, json, css, markdown]
       - id: eslint
         name: eslint
         entry: npx eslint

--- a/apps/web/app/result/page.tsx
+++ b/apps/web/app/result/page.tsx
@@ -1,28 +1,30 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
-import LoadingState from '../../components/LoadingState';
-import ScoreDial from '../../components/ScoreDial';
-import SkillsList from '../../components/SkillsList';
-import GapsList from '../../components/GapsList';
-import ClusterBars from '../../components/ClusterBars';
-import TrustBox from '../../components/TrustBox';
+import LoadingState from '../components/LoadingState';
+import ScoreDial from '../components/ScoreDial';
+import SkillsList from '../components/SkillsList';
+import GapsList from '../components/GapsList';
+import ClusterBars from '../components/ClusterBars';
+import TrustBox from '../components/TrustBox';
 import type { ScoreResponse } from '@doesmyresumematch/shared';
 
 export default function ResultPage() {
-  const params = useParams();
-  const { id } = params as { id: string };
+  const [id, setId] = useState<string | null>(null);
   const [data, setData] = useState<ScoreResponse | null>(null);
   const [showRewrites, setShowRewrites] = useState(false);
   const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
   const ANALYTICS_ENABLED = process.env.NEXT_PUBLIC_ANALYTICS_ENABLED === '1';
 
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setId(params.get('id'));
+  }, []);
+
+  useEffect(() => {
+    if (!id) return;
     const stored =
-      typeof window !== 'undefined'
-        ? localStorage.getItem(`match-${id}`)
-        : null;
+      typeof window !== 'undefined' ? localStorage.getItem(`match-${id}`) : null;
     if (stored) {
       setData(JSON.parse(stored) as ScoreResponse);
     }
@@ -37,7 +39,7 @@ export default function ResultPage() {
     });
   }, [data, ANALYTICS_ENABLED, API_BASE]);
 
-  if (!data) return <LoadingState />;
+  if (!id || !data) return <LoadingState />;
 
   const handleExport = async () => {
     const res = await fetch(`/api/snapshot/${id}`);

--- a/apps/web/pages/api/snapshot/[id].tsx
+++ b/apps/web/pages/api/snapshot/[id].tsx
@@ -85,13 +85,14 @@ export default async function handler(
       </Document>
     );
 
-    const buffer = await pdf(doc).toBuffer();
+    const blob = await pdf(doc).toBlob();
+    const arrayBuffer = await blob.arrayBuffer();
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader(
       'Content-Disposition',
       `attachment; filename=doesmyresumematch-${id}.pdf`
     );
-    res.send(Buffer.from(buffer));
+    res.send(Buffer.from(arrayBuffer));
   } catch (e) {
     res.status(500).json({ error: 'failed to generate pdf' });
   }


### PR DESCRIPTION
## Summary
- fix PDF snapshot route by using blob buffer
- simplify result page to use query parameter so static export works
- correct prettier hook file types in pre-commit config

## Testing
- `pnpm lint`
- `pnpm --filter web build`
- `pre-commit run --files apps/web/pages/api/snapshot/[id].tsx apps/web/app/result/page.tsx .pre-commit-config.yaml` *(fails: pathspec 'v5.12.0' did not match any file(s) known to git)*

------
https://chatgpt.com/codex/tasks/task_e_68a76fd4ab2c832e95ebc37b901e64a2