### PR TITLE
fix: ensure pnpm available in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,15 +20,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - name: Enable pnpm
+        run: corepack enable
       - name: Install dependencies
         run: pnpm install
       - name: Build static site

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: ruff
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.12.0
+    rev: v5.9.3
     hooks:
       - id: isort
   - repo: local


### PR DESCRIPTION
## Summary
- install pnpm before build and enable it via corepack in deploy workflow
- fix isort pre-commit hook revision to a valid tag

## Testing
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/deploy.yml`
- `make test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...; npx playwright install --with-deps failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a77888391c832eb02eb1e1e5d72411