### PR TITLE
feat: add Render blueprint and env-based CORS

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import os
 import threading
 import time
 from collections import defaultdict
@@ -23,9 +24,13 @@ logging.basicConfig(level=logging.INFO)
 app = FastAPI()
 app.state.settings = settings
 
+allowed = os.getenv(
+    "ALLOW_ORIGINS", "https://doesmyresumematch-web.onrender.com"
+).split(",")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[o.strip() for o in allowed if o.strip()],
+    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,11 +1,10 @@
-/** @type {import('next').NextConfig} */
 const basePath = process.env.BASE_PATH || '';
 
-const nextConfig = {
+/** @type {import('next').NextConfig} */
+module.exports = {
   output: 'export',
-  images: { unoptimized: true },
-  assetPrefix: basePath ? `${basePath}/` : undefined,
   basePath,
+  assetPrefix: basePath ? `${basePath}/` : undefined,
+  images: { unoptimized: true },
+  trailingSlash: true,
 };
-
-module.exports = nextConfig;

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,52 @@
+services:
+  # --- FastAPI backend ---
+  - type: web
+    name: doesmyresumematch-api
+    env: python
+    plan: free
+    region: oregon
+    buildCommand: |
+      pip install -r apps/api/requirements.txt
+    startCommand: |
+      cd apps/api && alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /healthz
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: dmr-db
+          property: connectionString
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: ALLOW_ORIGINS
+        # Allow your frontend origin(s). Update with your custom domain later if you add one.
+        value: https://doesmyresumematch-web.onrender.com
+
+  # --- Postgres (pgvector if you use it) ---
+  - type: postgres
+    name: dmr-db
+    plan: free
+    ipAllowList: []
+
+  # --- Static Next.js frontend (Next.js 'export') ---
+  - type: static_site
+    name: doesmyresumematch-web
+    envVars:
+      - key: NEXT_PUBLIC_API_BASE
+        value: https://doesmyresumematch-api.onrender.com
+      - key: BASE_PATH
+        value: ""    # empty because site is served at root on Render
+    buildCommand: |
+      corepack enable
+      corepack prepare pnpm@9 --activate
+      pnpm install -w
+      pnpm --filter web build
+    publishPath: apps/web/out
+    # Optional: SPA-style fallback if you use client-side routing
+    routes:
+      - type: redirect
+        source: /_next/static/*
+        destination: /_next/static/:splat
+      - type: rewrite
+        source: /*
+        destination: /index.html
+

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -6,6 +6,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "apps/api"))
 
 os.environ.setdefault("DEV_MODE", "1")
+os.environ.setdefault("ALLOW_ORIGINS", "http://localhost:3000")
 
 from app.main import app  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
@@ -57,4 +58,7 @@ def test_cors_preflight():
         },
     )
     assert res.status_code == 200
-    assert res.headers.get("access-control-allow-origin") == "*"
+    assert (
+        res.headers.get("access-control-allow-origin")
+        == "http://localhost:3000"
+    )


### PR DESCRIPTION
## Summary
- add Render deployment blueprint
- support export without base path in Next.js
- configure CORS origins via environment variable

## Testing
- `pytest`
- `pnpm --filter web build`


------
https://chatgpt.com/codex/tasks/task_e_68a7a952ffa0832ebe6c5729a9c53354