### PR TITLE
Fix result routing to prevent 404

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -72,7 +72,7 @@ export default function Page() {
       const matchData = await matchRes.json();
       const id = Date.now().toString();
       localStorage.setItem(`match-${id}`, JSON.stringify(matchData));
-      router.push(`/result/${id}`);
+      router.push(`/result?id=${id}`);
     } catch (e) {
       console.error(e);
       alert('Request failed');


### PR DESCRIPTION
## Summary
- route users to `/result?id=ID` so pages work on GitHub Pages export

## Testing
- `pre-commit run --files apps/web/app/page.tsx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b486eedc832e9938d3caaefa6aae